### PR TITLE
fix the code block syntax

### DIFF
--- a/src/content/blog/Claude Code Best Practices and Pro Tips.md
+++ b/src/content/blog/Claude Code Best Practices and Pro Tips.md
@@ -209,7 +209,8 @@ MCP allows Claude Code to interact with various tools and services.
     You can use the fetch capability to provide Claude with any knowledge from a URL that it might need for a task. For example, to build a game based on specific rules:
     ```
     > write pseudo code to describe the rules of uno based on here: https://www.unorules.com/
-    ```    Claude will fetch the rules:
+    ```
+    Claude will fetch the rules:
     ```
     * Fetch(https://www.unorules.com/)...
     Received 123.8KB (200 OK)


### PR DESCRIPTION
the code block isn't currently showing correctly because the markdown isn't formatted correctly.

<img width="1007" height="717" alt="Screenshot from 2025-09-16 22-37-11" src="https://github.com/user-attachments/assets/fb3dd4a9-8984-4839-a65a-8adf8f586e6e" />

This commit fixes the formatting so the code block displays correctly when viewed as markdown.